### PR TITLE
feat: update page reload delay

### DIFF
--- a/LSS Schrotthändler.user.js
+++ b/LSS Schrotthändler.user.js
@@ -71,10 +71,10 @@ function deleteSelectedVehicle() {
             }, index * 100);
         });
 
-        // Warte 100ms und lade dann die Seite neu
+        // Warte 100ms für jedes zu löschende Fahrzeug und lade dann die Seite neu
         setTimeout(function () {
             location.reload();
-        }, 100);
+        }, 100 * vehicleIdsToDelete.length);
     } else {
         console.log("Löschvorgang abgebrochen.");
     }


### PR DESCRIPTION
Ein kleines Improvment, die Zeit bis zum Nachladen der Seite ist damit abhaengig von der Anzahl der zu loeschenden Fahrzeuge.
Vor allem bei vielen Fahrzeugen ist dies notwendig, da sonst das Skript recht haeufig ausgefuehrt werden muss (in meinem Fall waeren das >50x gewesen).